### PR TITLE
Make this library work with browsers that don't support arrow functions.

### DIFF
--- a/src/tests/unit/ModuleUtils/CorrectCases.js
+++ b/src/tests/unit/ModuleUtils/CorrectCases.js
@@ -6,7 +6,7 @@ export default (utilsModule) => {
       test('with an arrow function', () => {
         const actual = utilsModule.makeResponse(() => 'a')
         const expected = `
-  self.onmessage = event => {
+  self.onmessage = function(event) {
     const args = event.data.message.args
     if (args) {
       self.postMessage((function () {return 'a';}).apply(null, args))
@@ -22,7 +22,7 @@ export default (utilsModule) => {
       test('with a function expression', () => {
         const actual = utilsModule.makeResponse(function () { return 'a' })
         const expected = `
-  self.onmessage = event => {
+  self.onmessage = function(event) {
     const args = event.data.message.args
     if (args) {
       self.postMessage((function () {return 'a';}).apply(null, args))

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,7 +60,7 @@ const argumentError = ({ expected = '', received, extraInfo = '' }) => {
 
 // Response builder
 const makeResponse = work => `
-  self.onmessage = event => {
+  self.onmessage = function(event) {
     const args = event.data.message.args
     if (args) {
       self.postMessage((${work}).apply(null, args))


### PR DESCRIPTION
**Problem:**
Using this library with browsers that don't support arrow functions breaks because we essentially are running a sneaky `eval` as a Blob within a WebWorker.  This doesn't get caught by systems like `babel` because the function is hard-coded as text.

**Solution:**
Update text function to use a function expression instead.