### PR TITLE
not failing in module scope when run in node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,9 @@ import { create } from './create'
 import { run } from './run'
 
 const createWrapper = () => {
+  if ('undefined' === typeof window) {
+    return null;
+  }
   if (!window.Worker) {
     console.error('This browser does not support Workers.')
     return null


### PR DESCRIPTION
For universal (a.k.a. "isomorphic") rendering: Even though this is a web-only module, it's important to not fail when imported server-side, because sometimes that's where components get rendered.